### PR TITLE
feat: add PDFLoader #1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- PDFLoader with support for per-page and whole-file modes (closes #1)
 ## [0.1.0] - 2026-03-24
 
 ### Added

--- a/ragframework/document/__init__.py
+++ b/ragframework/document/__init__.py
@@ -1,11 +1,12 @@
 """Document loading and chunking utilities."""
 
 from ragframework.document.chunkers import FixedSizeChunker, SentenceChunker
-from ragframework.document.loaders import MarkdownLoader, TextFileLoader
+from .loaders import TextFileLoader, MarkdownLoader, PDFLoader
 
 __all__ = [
     "TextFileLoader",
     "MarkdownLoader",
+    "PDFLoader",
     "FixedSizeChunker",
     "SentenceChunker",
 ]

--- a/ragframework/document/loaders.py
+++ b/ragframework/document/loaders.py
@@ -1,7 +1,7 @@
 """Built-in document loaders.
 
-These loaders handle plain text and Markdown files with no extra dependencies.
-For PDF, DOCX, HTML, and other formats see the open issues in
+These loaders handle plain text and Markdown files, PDF with no extra dependencies.
+For DOCX, HTML, and other formats see the open issues in
 `.github/GOOD_FIRST_ISSUES.md`.
 """
 
@@ -71,3 +71,81 @@ class MarkdownLoader(DocumentLoader):
                 metadata={"source": source, "filename": path.name, "format": "markdown"},
             )
         ]
+
+
+class PDFLoader(DocumentLoader):
+    """Load a PDF file into one or more :class:`Document` objects.
+    By default, each page is loaded as a separate document with metadata indicating the page number.
+    To load the entire PDF as a single document, set ``split_pages=False``
+    """
+
+    def __init__(self, split_pages: bool = True) -> None:
+        self.split_pages = split_pages
+
+    def load(self, source: str) -> list[Document]:
+        path = Path(source)
+
+        if not path.exists():
+            raise LoaderError(f"File not found: {source}")
+        if not path.is_file():
+            raise LoaderError(f"Not a file: {source}")
+
+        try:
+            from pypdf import PdfReader
+        except ImportError as exc:
+            raise ImportError("PDF support requires 'ragframework[pdf]'. " "Install it with: pip install ragframework[pdf]") from exc
+
+        # Open the PDF
+        try:
+            reader = PdfReader(str(path))
+        except Exception as exc:
+            raise LoaderError(f"Could not read PDF file {source}: {exc}") from exc
+
+        documents: list[Document] = []
+
+        if not self.split_pages:
+            # One single Document for the whole PDF
+            try:
+                full_text = "\n\n".join(
+                    page.extract_text() or "" for page in reader.pages
+                )
+            except Exception as exc:
+                raise LoaderError(f"Failed to extract text from {source}: {exc}") from exc
+
+            documents.append(
+                Document(
+                    id=_make_id(source),
+                    content=full_text.strip(),
+                    metadata={
+                        "source": source,
+                        "filename": path.name,
+                        "format": "pdf",
+                        "total_pages": len(reader.pages),
+                        "split_pages": False,
+                    },
+                )
+            )
+        else:
+            # One Document per page (default)
+            for i, page in enumerate(reader.pages, start=1):
+                try:
+                    text = page.extract_text() or ""
+                except Exception as exc:
+                    raise LoaderError(
+                        f"Failed to extract text from page {i} of {source}: {exc}"
+                    ) from exc
+
+                documents.append(
+                    Document(
+                        id=_make_id(f"{source}_page{i}"),
+                        content=text,
+                        metadata={
+                            "source": source,
+                            "filename": path.name,
+                            "format": "pdf",
+                            "page_number": i,
+                            "total_pages": len(reader.pages),
+                        },
+                    )
+                )
+        return documents

--- a/tests/test_document/test_loaders.py
+++ b/tests/test_document/test_loaders.py
@@ -1,8 +1,12 @@
 """Tests for built-in document loaders."""
 
+import builtins
+import sys
+import types
+
 import pytest
 
-from ragframework.document.loaders import MarkdownLoader, TextFileLoader
+from ragframework.document.loaders import MarkdownLoader, TextFileLoader, PDFLoader
 from ragframework.exceptions import LoaderError
 
 
@@ -43,3 +47,53 @@ class TestMarkdownLoader:
         loader = MarkdownLoader()
         with pytest.raises(LoaderError):
             loader.load("/no/such/file.md")
+
+
+def test_pdf_loader_requires_pypdf(tmp_path, monkeypatch):
+    pdf_path = tmp_path / "doc.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4\n%EOF\n")
+
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "pypdf":
+            raise ImportError("No module named 'pypdf'")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    loader = PDFLoader()
+    with pytest.raises(ImportError, match=r"PDF support requires 'ragframework\[pdf\]'"):
+        loader.load(str(pdf_path))
+
+
+def test_pdf_loader_loads_pages_with_fake_pypdf(tmp_path, monkeypatch):
+    class FakePage:
+        def __init__(self, text):
+            self._text = text
+
+        def extract_text(self):
+            return self._text
+
+    class FakePdfReader:
+        def __init__(self, source):
+            self.pages = [FakePage("page1"), FakePage("page2")]
+
+    fake_pypdf = types.SimpleNamespace(PdfReader=FakePdfReader)
+    monkeypatch.setitem(sys.modules, "pypdf", fake_pypdf)
+
+    pdf_path = tmp_path / "doc.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4\n%EOF\n")
+
+    loader = PDFLoader(split_pages=True)
+    docs = loader.load(str(pdf_path))
+
+    assert len(docs) == 2
+    assert docs[0].content == "page1"
+    assert docs[1].content == "page2"
+
+    loader_whole = PDFLoader(split_pages=False)
+    docs_whole = loader_whole.load(str(pdf_path))
+    assert len(docs_whole) == 1
+    assert "page1" in docs_whole[0].content
+    assert "page2" in docs_whole[0].content


### PR DESCRIPTION
## Description

<!-- Adds a PDFLoader for loading PDF documents into the RAG framework.
This enables support for one of the most common document formats used.
Link the related issue: "Closes #1" -->

Closes #1 

## Changes

<!-- Bullet-point list of what changed -->

- Implemented PDFLoader in ragframework/document/loaders.py
- Supports loading one document per page (default) and the entire PDF as a single Document 
- Extracts text using pypdf with guarded import
- Adds relevant metadata, e.g., source, filename, format, page_number (per-page mode), total_pages
- Raises LoaderError for file validation and extraction failures
- Exported PDFLoader in ragframework/document/__init__.py
- Updated CHANGELOG.md under [Unreleased]

## Type of change

- [ ] Bug fix
- [x] New feature / integration
- [ ] Documentation update
- [ ] Refactor / code quality

## Checklist

- [x] `pytest tests/ -v` passes locally
- [x] `ruff check ragframework/` passes
- [ ] `mypy ragframework/` passes
- [x] New or updated tests cover the changes
- [x] Optional dependencies are guarded with a helpful import error
- [x] Docstrings updated where applicable
- [x] `CHANGELOG.md` updated under `[Unreleased]`
