### PR TITLE
feat: add recursive text chunker (fixes #3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- RecursiveChunker for semantics-preserving text splitting (closes #3)
 - PDFLoader with support for per-page and whole-file modes (closes #1)
 ## [0.1.0] - 2026-03-24
 

--- a/ragframework/document/__init__.py
+++ b/ragframework/document/__init__.py
@@ -1,12 +1,14 @@
 """Document loading and chunking utilities."""
 
-from ragframework.document.chunkers import FixedSizeChunker, SentenceChunker
-from .loaders import TextFileLoader, MarkdownLoader, PDFLoader
+from ragframework.document.chunkers import FixedSizeChunker, RecursiveChunker, SentenceChunker
+
+from .loaders import MarkdownLoader, PDFLoader, TextFileLoader
 
 __all__ = [
     "TextFileLoader",
     "MarkdownLoader",
     "PDFLoader",
     "FixedSizeChunker",
+    "RecursiveChunker",
     "SentenceChunker",
 ]

--- a/ragframework/document/chunkers.py
+++ b/ragframework/document/chunkers.py
@@ -169,6 +169,8 @@ class RecursiveChunker(TextChunker):
             while idx < len(text):
                 end = min(idx + self.chunk_size, len(text))
                 result.append(text[idx:end])
+                if end == len(text):
+                    break
                 idx += step
                 if step <= 0:
                     break

--- a/ragframework/document/chunkers.py
+++ b/ragframework/document/chunkers.py
@@ -96,3 +96,147 @@ class SentenceChunker(TextChunker):
             chunk_num += 1
             index += step
         return chunks
+
+
+class RecursiveChunker(TextChunker):
+    """Split text recursively using a hierarchy of separators.
+
+    Args:
+        separators: List of separators to use. Defaults to paragraphs, lines, sentences, words, chars.
+        chunk_size: Maximum number of characters per chunk.
+        chunk_overlap: Maximum number of overlapping characters between adjacent chunks.
+    """
+
+    def __init__(
+        self,
+        separators: list[str] | None = None,
+        chunk_size: int = 512,
+        chunk_overlap: int = 64,
+    ) -> None:
+        if chunk_size <= 0:
+            raise ValueError("chunk_size must be positive")
+        if chunk_overlap < 0:
+            raise ValueError("chunk_overlap must be non-negative")
+        if chunk_overlap >= chunk_size:
+            raise ValueError("chunk_overlap must be less than chunk_size")
+
+        self.separators = (
+            list(separators) if separators is not None else ["\n\n", "\n", ". ", " ", ""]
+        )
+        self.chunk_size = chunk_size
+        self.chunk_overlap = chunk_overlap
+
+    def chunk(self, document: Document) -> list[Chunk]:
+        if not document.content:
+            return []
+
+        text_chunks = self._split_text(document.content, self.separators)
+
+        chunks: list[Chunk] = []
+        for i, content in enumerate(text_chunks):
+            chunks.append(
+                Chunk(
+                    id=f"{document.id}:{i}",
+                    content=content,
+                    # We create a new dict for metadata as requested to avoid mutating document metadata
+                    metadata={**document.metadata, "chunk_index": i},
+                )
+            )
+        return chunks
+
+    def _split_text(self, text: str, separators: list[str]) -> list[str]:
+        if len(text) <= self.chunk_size:
+            return [text]
+
+        separator = ""
+        next_separators: list[str] = []
+
+        if separators:
+            for i, sep in enumerate(separators):
+                if sep == "":
+                    separator = sep
+                    next_separators = separators[i + 1 :]
+                    break
+                if sep in text:
+                    separator = sep
+                    next_separators = separators[i + 1 :]
+                    break
+
+        if separator == "":
+            result = []
+            step = self.chunk_size - self.chunk_overlap
+            idx = 0
+            while idx < len(text):
+                end = min(idx + self.chunk_size, len(text))
+                result.append(text[idx:end])
+                idx += step
+                if step <= 0:
+                    break
+            return result
+
+        pieces = text.split(separator)
+        # Reconstruct separators between pieces
+        for i in range(len(pieces) - 1):
+            pieces[i] += separator
+
+        return self._merge_pieces(pieces, next_separators)
+
+    def _merge_pieces(self, pieces: list[str], next_separators: list[str]) -> list[str]:
+        final_chunks: list[str] = []
+        current_chunk_pieces: list[str] = []
+        current_length = 0
+
+        for piece in pieces:
+            if len(piece) > self.chunk_size:
+                if current_chunk_pieces:
+                    final_chunks.append("".join(current_chunk_pieces))
+
+                    overlap_pieces: list[str] = []
+                    for p in reversed(current_chunk_pieces):
+                        next_overlap = [p] + overlap_pieces
+                        next_len = sum(len(x) for x in next_overlap)
+                        if next_len <= self.chunk_overlap:
+                            overlap_pieces = next_overlap
+                        else:
+                            break
+
+                    piece = "".join(overlap_pieces) + piece
+                    current_chunk_pieces = []
+                    current_length = 0
+
+                sub_chunks = self._split_text(piece, next_separators)
+
+                if len(sub_chunks) > 1:
+                    final_chunks.extend(sub_chunks[:-1])
+
+                if sub_chunks:
+                    current_chunk_pieces = [sub_chunks[-1]]
+                    current_length = len(sub_chunks[-1])
+            else:
+                added_length = len(piece)
+                if current_length + added_length <= self.chunk_size:
+                    current_chunk_pieces.append(piece)
+                    current_length += added_length
+                else:
+                    final_chunks.append("".join(current_chunk_pieces))
+
+                    overlap_pieces = []
+                    for p in reversed(current_chunk_pieces):
+                        next_overlap_pieces = [p] + overlap_pieces
+                        next_overlap_length = sum(len(x) for x in next_overlap_pieces)
+
+                        if (
+                            next_overlap_length <= self.chunk_overlap
+                            and next_overlap_length + len(piece) <= self.chunk_size
+                        ):
+                            overlap_pieces = next_overlap_pieces
+                        else:
+                            break
+
+                    current_chunk_pieces = overlap_pieces + [piece] if overlap_pieces else [piece]
+                    current_length = sum(len(x) for x in current_chunk_pieces)
+
+        if current_chunk_pieces:
+            final_chunks.append("".join(current_chunk_pieces))
+
+        return final_chunks

--- a/tests/test_document/test_chunkers.py
+++ b/tests/test_document/test_chunkers.py
@@ -169,3 +169,15 @@ class TestRecursiveChunker:
         doc2 = Document(id="x", content="a b c", metadata={})
         chunks = chunker.chunk(doc2)
         assert [c.content for c in chunks] == ["a b ", "c"]
+
+    def test_redundant_trailing_chunks(self):
+        from ragframework.document.chunkers import RecursiveChunker
+
+        doc = Document(id="x", content="x" * 10, metadata={})
+        chunker = RecursiveChunker(
+            separators=[],
+            chunk_size=6,
+            chunk_overlap=4,
+        )
+        chunks = chunker.chunk(doc)
+        assert [len(c.content) for c in chunks] == [6, 6, 6]

--- a/tests/test_document/test_chunkers.py
+++ b/tests/test_document/test_chunkers.py
@@ -65,3 +65,107 @@ class TestSentenceChunker:
         doc = Document(id="x", content="", metadata={})
         chunker = SentenceChunker()
         assert chunker.chunk(doc) == []
+
+
+class TestRecursiveChunker:
+    def test_empty_doc(self):
+        from ragframework.document.chunkers import RecursiveChunker
+
+        doc = Document(id="x", content="", metadata={})
+        chunker = RecursiveChunker()
+        chunks = chunker.chunk(doc)
+        assert chunks == []
+
+    def test_short_doc(self):
+        from ragframework.document.chunkers import RecursiveChunker
+
+        doc = Document(id="x", content="Short", metadata={})
+        chunker = RecursiveChunker(chunk_size=10, chunk_overlap=0)
+        chunks = chunker.chunk(doc)
+        assert len(chunks) == 1
+        assert chunks[0].content == "Short"
+
+    def test_exact_size_doc(self):
+        from ragframework.document.chunkers import RecursiveChunker
+
+        doc = Document(id="x", content="Exactly10!", metadata={})
+        chunker = RecursiveChunker(chunk_size=10, chunk_overlap=0)
+        chunks = chunker.chunk(doc)
+        assert len(chunks) == 1
+        assert chunks[0].content == "Exactly10!"
+
+    def test_oversized_doc_long_word(self, long_doc):
+        from ragframework.document.chunkers import RecursiveChunker
+
+        # long_doc is "A" * 200
+        chunker = RecursiveChunker(chunk_size=50, chunk_overlap=10)
+        chunks = chunker.chunk(long_doc)
+        assert len(chunks) > 1
+        for chunk in chunks:
+            assert len(chunk.content) <= 50
+
+    def test_single_custom_separator(self):
+        from ragframework.document.chunkers import RecursiveChunker
+
+        doc = Document(id="x", content="a,b,c,d,e,f", metadata={})
+        chunker = RecursiveChunker(separators=[","], chunk_size=4, chunk_overlap=0)
+        chunks = chunker.chunk(doc)
+        # "a,b" is 3 chars. "c,d" is 3 chars.
+        assert [c.content for c in chunks] == ["a,b,", "c,d,", "e,f"]
+
+    def test_overlap_behavior(self):
+        from ragframework.document.chunkers import RecursiveChunker
+
+        # 3 words of length 5 + spaces
+        doc = Document(id="x", content="Hello world today", metadata={})
+        chunker = RecursiveChunker(chunk_size=12, chunk_overlap=6)
+        chunks = chunker.chunk(doc)
+        # "Hello world" is 11 chars. Next is "world today" which is 11 chars.
+        assert [c.content for c in chunks] == ["Hello world ", "world today"]
+
+    def test_text_preservation(self):
+        from ragframework.document.chunkers import RecursiveChunker
+
+        text = "Paragraph 1\n\nParagraph 2 is slightly longer.\n\nParagraph 3."
+        doc = Document(id="x", content=text, metadata={})
+        chunker = RecursiveChunker(chunk_size=20, chunk_overlap=0)
+        chunks = chunker.chunk(doc)
+        assert "".join(c.content for c in chunks) == text
+
+    def test_metadata_and_ids(self):
+        from ragframework.document.chunkers import RecursiveChunker
+
+        doc = Document(id="doc1", content="A B C", metadata={"author": "test"})
+        chunker = RecursiveChunker(chunk_size=1, chunk_overlap=0)
+        chunks = chunker.chunk(doc)
+        assert chunks[0].id == "doc1:0"
+        assert chunks[0].metadata["author"] == "test"
+        assert chunks[0].metadata["chunk_index"] == 0
+        assert chunks[1].id == "doc1:1"
+
+    def test_validation(self):
+        from ragframework.document.chunkers import RecursiveChunker
+
+        with pytest.raises(ValueError):
+            RecursiveChunker(chunk_size=0)
+        with pytest.raises(ValueError):
+            RecursiveChunker(chunk_size=10, chunk_overlap=-1)
+        with pytest.raises(ValueError):
+            RecursiveChunker(chunk_size=10, chunk_overlap=10)
+        with pytest.raises(ValueError):
+            RecursiveChunker(chunk_size=10, chunk_overlap=15)
+
+    def test_edge_cases(self):
+        from ragframework.document.chunkers import RecursiveChunker
+
+        # empty separators
+        doc = Document(id="x", content="abcdef", metadata={})
+        chunker = RecursiveChunker(separators=[], chunk_size=3, chunk_overlap=1)
+        chunks = chunker.chunk(doc)
+        assert [c.content for c in chunks] == ["abc", "cde", "ef"]
+
+        # duplicate separators
+        chunker = RecursiveChunker(separators=[" ", " "], chunk_size=4, chunk_overlap=0)
+        doc2 = Document(id="x", content="a b c", metadata={})
+        chunks = chunker.chunk(doc2)
+        assert [c.content for c in chunks] == ["a b ", "c"]


### PR DESCRIPTION
## Summary

Implement `RecursiveChunker` for Issue #3 with recursive structural splitting, bounded overlap, and character-level fallback.

## What Changed

- Added `RecursiveChunker` to `ragframework.document.chunkers`
- Added recursive separator hierarchy:
  paragraphs → lines → sentences → words → characters
- Added hard chunk-size enforcement
- Added segment-aware bounded overlap
- Added character-level fallback for oversized text
- Added public export in `ragframework/document/__init__.py`
- Updated `CHANGELOG.md`
- Added unit tests covering required behavior and edge cases

## Correctness

- Empty documents return `[]`.
- Every output chunk respects the configured `chunk_size`.
- Overlap never exceeds the configured `chunk_overlap`.
- With `chunk_overlap=0`, chunk contents reconstruct the original document exactly.
- Document metadata is copied rather than mutated.
- Chunk IDs follow the existing deterministic convention.

## Validation

- `pytest tests/` — 43/43 tests passed
- `ruff check .` — passed
- `black --check .` — passed
- `isort --check-only .` — passed
- `mypy ragframework/` — passed

## Scope

Existing `FixedSizeChunker` and `SentenceChunker` implementations were left unchanged. No external dependencies or unrelated framework changes were introduced.

Fixes #3
